### PR TITLE
Remove filename variable for xorCondition error

### DIFF
--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -1623,7 +1623,7 @@ In other cases, gmd:otherConstraints shall include a non-empty free text element
 	  </LangTranslationTemplateCollection>
 	  <LangTranslationTemplateCollection name="TR.xorAllConditionsMatched">
 		 <translationTemplates>
-			<TranslationTemplate language="en" name="TR.xorAllConditionsMatched">XML document '{filename}': Evaluation of the XOR conditon failed: All conditions were matched</TranslationTemplate>
+			<TranslationTemplate language="en" name="TR.xorAllConditionsMatched">Evaluation of the XOR conditon failed: All conditions were matched</TranslationTemplate>
 		 </translationTemplates>
 	  </LangTranslationTemplateCollection>
 		<LangTranslationTemplateCollection name="TR.invalidPropertyValueError">


### PR DESCRIPTION
Right now XOR (Exclusive OR conditions) XQuery expressions don't provide context information about the current file being evaluated. Because of that, the filename is removed from the placeholder to prevent errors when running the Test definitions in the validator